### PR TITLE
Move all endpoint parameters to query

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CryptoExchangeAPIs"
 uuid = "5e3d4798-c815-4641-85e1-deed530626d3"
-version = "0.28.0"
+version = "0.29.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/Coinbase/Spot/API/Candle.jl
+++ b/src/Coinbase/Spot/API/Candle.jl
@@ -14,9 +14,12 @@ using CryptoExchangeAPIs: Maybe, APIsRequest
 
 Base.@kwdef struct CandleQuery <: CoinbasePublicQuery
     granularity::TimeInterval
+    product_id::String
     start::Maybe{DateTime} = nothing
     _end::Maybe{DateTime} = nothing
 end
+
+Serde.SerQuery.ser_ignore_field(::Type{CandleQuery}, ::Val{:product_id}) = true
 
 function Serde.ser_type(::Type{<:CandleQuery}, x::TimeInterval)::String
     x == m1  && return "60"
@@ -49,6 +52,7 @@ Get rates for a single product by product ID, grouped in buckets.
 | Parameter   | Type         | Required | Description        |
 |:------------|:-------------|:---------|:-------------------|
 | granularity | TimeInterval | true     | m1 m5 m15 h1 h6 d1 |
+| product_id  | String       | true     |                    |
 | start       | DateTime     | false    |                    |
 | _end        | DateTime     | false    |                    |
 
@@ -59,7 +63,8 @@ using Serde
 using CryptoExchangeAPIs.Coinbase
 
 result = Coinbase.Spot.candle(;
-    granularity = Coinbase.Spot.Candle.d1
+    granularity = Coinbase.Spot.Candle.d1,
+    product_id = "BTC-USD",
 )
 
 to_pretty_json(result.result)
@@ -81,12 +86,12 @@ to_pretty_json(result.result)
 ]
 ```
 """
-function candle(client::CoinbaseClient, query::CandleQuery; product_id::String)
-    return APIsRequest{Vector{CandleData}}("GET", "products/$product_id/candles", query)(client)
+function candle(client::CoinbaseClient, query::CandleQuery;)
+    return APIsRequest{Vector{CandleData}}("GET", "products/$(query.product_id)/candles", query)(client)
 end
 
-function candle(client::CoinbaseClient = Coinbase.Spot.public_client; product_id::String, kw...)
-    return candle(client, CandleQuery(; kw...); product_id = product_id)
+function candle(client::CoinbaseClient = Coinbase.Spot.public_client; kw...)
+    return candle(client, CandleQuery(; kw...))
 end
 
 end

--- a/src/Coinbase/Spot/API/ProductStats.jl
+++ b/src/Coinbase/Spot/API/ProductStats.jl
@@ -11,8 +11,10 @@ using CryptoExchangeAPIs.Coinbase
 using CryptoExchangeAPIs: Maybe, APIsRequest
 
 Base.@kwdef struct ProductStatsQuery <: CoinbasePublicQuery
-    #__ empty
+    product_id::String
 end
+
+Serde.SerQuery.ser_ignore_field(::Type{ProductStatsQuery}, ::Val{:product_id}) = true
 
 struct ProductStatsData <: CoinbaseData
     open::Float64
@@ -35,13 +37,21 @@ Get rates for a single product by product ID, grouped in buckets.
 
 [`GET products/{product_id}/stats`](https://docs.cloud.coinbase.com/exchange/reference/exchangerestapi_getproductstats)
 
+## Parameters:
+
+| Parameter  | Type     | Required | Description |
+|:-----------|:---------|:---------|:------------|
+| product_id | String   | true     |             |
+
 ## Code samples:
 
 ```julia
 using Serde
 using CryptoExchangeAPIs.Coinbase
 
-result = Coinbase.Spot.product_stats()
+result = Coinbase.Spot.product_stats(;
+    product_id = "BTC-USD",
+)
 
 to_pretty_json(result.result)
 ```
@@ -63,12 +73,12 @@ to_pretty_json(result.result)
 }
 ```
 """
-function product_stats(client::CoinbaseClient, query::ProductStatsQuery; product_id::String)
-    return APIsRequest{ProductStatsData}("GET", "products/$product_id/stats", query)(client)
+function product_stats(client::CoinbaseClient, query::ProductStatsQuery;)
+    return APIsRequest{ProductStatsData}("GET", "products/$(query.product_id)/stats", query)(client)
 end
 
-function product_stats(client::CoinbaseClient = Coinbase.Spot.public_client; product_id::String, kw...)
-    return product_stats(client, ProductStatsQuery(; kw...); product_id = product_id)
+function product_stats(client::CoinbaseClient = Coinbase.Spot.public_client; kw...)
+    return product_stats(client, ProductStatsQuery(; kw...))
 end
 
 end

--- a/src/Coinbase/Spot/API/Ticker.jl
+++ b/src/Coinbase/Spot/API/Ticker.jl
@@ -11,8 +11,10 @@ using CryptoExchangeAPIs.Coinbase
 using CryptoExchangeAPIs: Maybe, APIsRequest
 
 Base.@kwdef struct TickerQuery <: CoinbasePublicQuery
-    #__ empty
+    product_id::String
 end
+
+Serde.SerQuery.ser_ignore_field(::Type{TickerQuery}, ::Val{:product_id}) = true
 
 struct TickerData <: CoinbaseData
     ask::Float64
@@ -31,6 +33,12 @@ end
 Gets snapshot information about the last trade (tick), best bid/ask and 24h volume.
 
 [`GET products/{product_id}/ticker`](https://docs.cloud.coinbase.com/exchange/reference/exchangerestapi_getproductticker)
+
+## Parameters:
+
+| Parameter  | Type     | Required | Description |
+|:-----------|:---------|:---------|:------------|
+| product_id | String   | true     |             |
 
 ## Code samples:
 
@@ -59,12 +67,12 @@ to_pretty_json(result.result)
 }
 ```
 """
-function ticker(client::CoinbaseClient, query::TickerQuery; product_id::String)
-    return APIsRequest{TickerData}("GET", "products/$product_id/ticker", query)(client)
+function ticker(client::CoinbaseClient, query::TickerQuery;)
+    return APIsRequest{TickerData}("GET", "products/$(query.product_id)/ticker", query)(client)
 end
 
-function ticker(client::CoinbaseClient = Coinbase.Spot.public_client; product_id::String, kw...)
-    return ticker(client, TickerQuery(; kw...); product_id = product_id)
+function ticker(client::CoinbaseClient = Coinbase.Spot.public_client; kw...)
+    return ticker(client, TickerQuery(; kw...))
 end
 
 end

--- a/src/Gateio/Futures/API/Candle.jl
+++ b/src/Gateio/Futures/API/Candle.jl
@@ -23,21 +23,25 @@ end
 
 struct CandleQuery <: GateioPublicQuery
     contract::Contract
+    settle::Settle
     from::Maybe{DateTime}
     to::Maybe{DateTime}
     limit::Maybe{Int64} 
     interval::Maybe{TimeInterval}
 end
 
+Serde.SerQuery.ser_ignore_field(::Type{CandleQuery}, ::Val{:settle}) = true
+
 function CandleQuery(;
     type::ContractType,
     name::String,
+    settle::Settle,
     from::Maybe{DateTime} = nothing,
     to::Maybe{DateTime} = nothing,
     limit::Maybe{Int64} = nothing,
     interval::Maybe{TimeInterval} = nothing,
 )
-    return CandleQuery(Contract(type, name), from, to, limit, interval)
+    return CandleQuery(Contract(type, name), settle, from, to, limit, interval)
 end
 
 function Serde.ser_type(::Type{<:CandleQuery}, x::Contract)::String
@@ -81,6 +85,7 @@ Get futures candlesticks.
 | Parameter | Type         | Required | Description                          |
 |:----------|:-------------|:---------|:-------------------------------------|
 | contract  | String       | true     |                                      |
+| settle    | Settle       | true     | btc usdt usd                         |
 | interval  | TimeInterval | false    | s10 m1 m5 m15 m30 h1 h4 h8 d1 d7 d30 |
 | from      | DateTime     | false    |                                      |
 | to        | DateTime     | false    |                                      |
@@ -119,12 +124,12 @@ to_pretty_json(result.result)
 ]
 ```
 """
-function candle(client::GateioClient, settle::Settle, query::CandleQuery)
-    return APIsRequest{Vector{CandleData}}("GET", "api/v4/futures/$settle/candlesticks", query)(client)
+function candle(client::GateioClient, query::CandleQuery)
+    return APIsRequest{Vector{CandleData}}("GET", "api/v4/futures/$(query.settle)/candlesticks", query)(client)
 end
 
-function candle(client::GateioClient = Gateio.Futures.public_client; settle::Settle, kw...)
-    return candle(client, settle, CandleQuery(; kw...))
+function candle(client::GateioClient = Gateio.Futures.public_client; kw...)
+    return candle(client, CandleQuery(; kw...))
 end
 
 end

--- a/src/Gateio/Futures/API/Contract.jl
+++ b/src/Gateio/Futures/API/Contract.jl
@@ -13,9 +13,12 @@ using CryptoExchangeAPIs: Maybe, APIsRequest
 @enum Settle btc usdt usd
 
 Base.@kwdef struct ContractQuery <: GateioPublicQuery
+    settle::Settle
     limit::Maybe{Int64} = nothing
     offset::Maybe{Int64} = nothing
 end
+
+Serde.SerQuery.ser_ignore_field(::Type{ContractQuery}, ::Val{:settle}) = true
 
 struct ContractData <: GateioData
     name::String
@@ -72,10 +75,11 @@ List all futures contracts.
 
 ## Parameters:
 
-| Parameter | Type     | Required | Description |
-|:----------|:---------|:---------|:------------|
-| limit     | Int64    | false    |             |
-| offset    | Int64    | false    |             |
+| Parameter | Type     | Required | Description  |
+|:----------|:---------|:---------|:-------------|
+| settle    | Settle   | true     | btc usdt usd |
+| limit     | Int64    | false    |              |
+| offset    | Int64    | false    |              |
 
 ## Code samples:
 
@@ -139,12 +143,12 @@ to_pretty_json(result.result)
 ]
 ```
 """
-function contract(client::GateioClient, settle::Settle, query::ContractQuery)
-    return APIsRequest{Vector{ContractData}}("GET", "api/v4/futures/$settle/contracts", query)(client)
+function contract(client::GateioClient, query::ContractQuery)
+    return APIsRequest{Vector{ContractData}}("GET", "api/v4/futures/$(query.settle)/contracts", query)(client)
 end
 
-function contract(client::GateioClient = Gateio.Futures.public_client; settle::Settle, kw...)
-    return contract(client, settle, ContractQuery(; kw...))
+function contract(client::GateioClient = Gateio.Futures.public_client; kw...)
+    return contract(client, ContractQuery(; kw...))
 end
 
 end

--- a/src/Gateio/Futures/API/FundingRate.jl
+++ b/src/Gateio/Futures/API/FundingRate.jl
@@ -14,8 +14,11 @@ using CryptoExchangeAPIs: Maybe, APIsRequest
 
 Base.@kwdef struct FundingRateQuery <: GateioPublicQuery
     contract::String
+    settle::Settle
     limit::Maybe{Int64} = nothing
 end
+
+Serde.SerQuery.ser_ignore_field(::Type{FundingRateQuery}, ::Val{:settle}) = true
 
 struct FundingRateData <: GateioData
     t::NanoDate
@@ -32,10 +35,11 @@ Funding rate history.
 
 ## Parameters:
 
-| Parameter | Type     | Required | Description |
-|:----------|:---------|:---------|:------------|
-| contract  | String   | true     |             |
-| limit     | Int64    | false    |             |
+| Parameter | Type     | Required | Description  |
+|:----------|:---------|:---------|:-------------|
+| settle    | Settle   | true     | btc usdt usd |
+| contract  | String   | true     |              |
+| limit     | Int64    | false    |              |
 
 ## Code samples:
 
@@ -63,12 +67,12 @@ to_pretty_json(result.result)
 ]
 ```
 """
-function funding_rate(client::GateioClient, settle::Settle, query::FundingRateQuery)
-    return APIsRequest{Vector{FundingRateData}}("GET", "api/v4/futures/$settle/funding_rate", query)(client)
+function funding_rate(client::GateioClient, query::FundingRateQuery)
+    return APIsRequest{Vector{FundingRateData}}("GET", "api/v4/futures/$(query.settle)/funding_rate", query)(client)
 end
 
-function funding_rate(client::GateioClient = Gateio.Futures.public_client; settle::Settle, kw...)
-    return funding_rate(client, settle, FundingRateQuery(; kw...))
+function funding_rate(client::GateioClient = Gateio.Futures.public_client; kw...)
+    return funding_rate(client, FundingRateQuery(; kw...))
 end
 
 end

--- a/src/Gateio/Futures/API/OrderBook.jl
+++ b/src/Gateio/Futures/API/OrderBook.jl
@@ -14,10 +14,13 @@ using CryptoExchangeAPIs: Maybe, APIsRequest
 
 Base.@kwdef struct OrderBookQuery <: GateioPublicQuery
     contract::String
+    settle::Settle
     interval::Maybe{String} = nothing
     limit::Maybe{Int64} = nothing
     with_id::Maybe{Bool} = nothing
 end
+
+Serde.SerQuery.ser_ignore_field(::Type{OrderBookQuery}, ::Val{:settle}) = true
 
 struct Order <: GateioData
     p::String
@@ -46,12 +49,13 @@ Futures order book.
 
 ## Parameters:
 
-| Parameter | Type     | Required | Description |
-|:----------|:---------|:---------|:------------|
-| contract  | String   | true     |             |
-| interval  | String   | false    |             |
-| limit     | Int64    | false    |             |
-| with_id   | Bool     | false    |             |
+| Parameter | Type     | Required | Description  |
+|:----------|:---------|:---------|:-------------|
+| contract  | String   | true     |              |
+| settle    | Settle   | true     | btc usdt usd |
+| interval  | String   | false    |              |
+| limit     | Int64    | false    |              |
+| with_id   | Bool     | false    |              |
 
 ## Code samples:
 
@@ -91,12 +95,12 @@ to_pretty_json(result.result)
 }
 ```
 """
-function order_book(client::GateioClient, settle::Settle, query::OrderBookQuery)
-    return APIsRequest{OrderBookData}("GET", "api/v4/futures/$settle/order_book", query)(client)
+function order_book(client::GateioClient, query::OrderBookQuery)
+    return APIsRequest{OrderBookData}("GET", "api/v4/futures/$(query.settle)/order_book", query)(client)
 end
 
-function order_book(client::GateioClient = Gateio.Futures.public_client; settle::Settle, kw...)
-    return order_book(client, settle, OrderBookQuery(; kw...))
+function order_book(client::GateioClient = Gateio.Futures.public_client; kw...)
+    return order_book(client, OrderBookQuery(; kw...))
 end
 
 end

--- a/src/Gateio/Futures/API/Ticker.jl
+++ b/src/Gateio/Futures/API/Ticker.jl
@@ -13,8 +13,11 @@ using CryptoExchangeAPIs: Maybe, APIsRequest
 @enum Settle btc usdt usd
 
 Base.@kwdef struct TickerQuery <: GateioPublicQuery
+    settle::Settle
     contract::Maybe{String} = nothing
 end
+
+Serde.SerQuery.ser_ignore_field(::Type{TickerQuery}, ::Val{:settle}) = true
 
 struct TickerData <: GateioData
     contract::String
@@ -47,9 +50,10 @@ List futures tickers.
 
 ## Parameters:
 
-| Parameter | Type     | Required | Description |
-|:----------|:---------|:---------|:------------|
-| contract  | String   | false    |             |
+| Parameter | Type     | Required | Description  |
+|:----------|:---------|:---------|:-------------|
+| settle    | Settle   | true     | btc usdt usd |
+| contract  | String   | false    |              |
 
 ## Code samples:
 
@@ -89,12 +93,12 @@ to_pretty_json(result.result)
 ]
 ```
 """
-function ticker(client::GateioClient, settle::Settle, query::TickerQuery)
-    return APIsRequest{Vector{TickerData}}("GET", "api/v4/futures/$settle/tickers", query)(client)
+function ticker(client::GateioClient, query::TickerQuery)
+    return APIsRequest{Vector{TickerData}}("GET", "api/v4/futures/$(query.settle)/tickers", query)(client)
 end
 
-function ticker(client::GateioClient = Gateio.Futures.public_client; settle::Settle, kw...)
-    return ticker(client, settle, TickerQuery(; kw...))
+function ticker(client::GateioClient = Gateio.Futures.public_client; kw...)
+    return ticker(client, TickerQuery(; kw...))
 end
 
 end

--- a/src/Poloniex/Spot/API/Candle.jl
+++ b/src/Poloniex/Spot/API/Candle.jl
@@ -20,9 +20,7 @@ Base.@kwdef struct CandleQuery <: PoloniexPublicQuery
     startTime::Maybe{DateTime} = nothing
 end
 
-function Serde.ser_ignore_field(::Type{<:CandleQuery}, ::Val{:symbol})::Bool
-    return true
-end
+Serde.SerQuery.ser_ignore_field(::Type{CandleQuery}, ::Val{:symbol}) = true
 
 function Serde.ser_type(::Type{<:CandleQuery}, x::TimeInterval)::String
     x == m1  && return "MINUTE_1"
@@ -68,13 +66,13 @@ Get latest trade price for all symbols.
 
 ## Parameters:
 
-| Parameter | Type         | Required | Description |
-|:----------|:-------------|:---------|:------------|
+| Parameter | Type         | Required | Description                                                               |
+|:----------|:-------------|:---------|:--------------------------------------------------------------------------|
 | interval  | TimeInterval | true     | `m1` `m5` `m10` `m15` `m30` `h1` `h2` `h4` `h6` `h12` `d1` `d3` `w1` `M1` |
-| symbol    | String       | false    |             |
-| startTime | DateTime     | false    |             |
-| endTime   | DateTime     | false    |             |
-| limit     | Int64        | false    |             |
+| symbol    | String       | false    |                                                                           |
+| startTime | DateTime     | false    |                                                                           |
+| endTime   | DateTime     | false    |                                                                           |
+| limit     | Int64        | false    |                                                                           |
 
 ## Code samples:
 

--- a/src/Poloniex/Spot/API/Market.jl
+++ b/src/Poloniex/Spot/API/Market.jl
@@ -14,9 +14,7 @@ Base.@kwdef struct MarketQuery <: PoloniexPublicQuery
     symbol::Maybe{String} = nothing
 end
 
-function Serde.ser_ignore_field(::Type{<:MarketQuery}, ::Val{:symbol})::Bool
-    return true
-end
+Serde.SerQuery.ser_ignore_field(::Type{MarketQuery}, ::Val{:symbol}) = true
 
 struct SymbolTradeLimit <: PoloniexData
     amountScale::Int64

--- a/src/Poloniex/Spot/API/OrderBook.jl
+++ b/src/Poloniex/Spot/API/OrderBook.jl
@@ -25,6 +25,8 @@ Base.@kwdef struct OrderBookQuery <: PoloniexPublicQuery
     scale::Maybe{Int64} = nothing
 end
 
+Serde.SerQuery.ser_ignore_field(::Type{OrderBookQuery}, ::Val{:symbol}) = true
+
 function Serde.SerQuery.ser_type(::Type{OrderBookQuery}, x::OrderBookLimit)::Int64
     return Int64(x)
 end
@@ -47,11 +49,11 @@ Get the order book for a given symbol.
 
 ## Parameters:
 
-| Parameter | Type           | Required | Description |
-|:----------|:---------------|:---------|:------------|
-| symbol    | String         | false    |             |
+| Parameter | Type           | Required | Description                                                                                 |
+|:----------|:---------------|:---------|:--------------------------------------------------------------------------------------------|
+| symbol    | String         | false    |                                                                                             |
 | limit     | OrderBookLimit | false    | `FIVE` (5), `TEN` (10), `TWENTY` (20), `FIFTY` (50), `HUNDRED` (100), `HUNDRED_FIFTY` (150) |
-| scale     | Int64          | false    |             |
+| scale     | Int64          | false    |                                                                                             |
 
 ## Code samples:
 


### PR DESCRIPTION
### Pull request checklist

Moving all query parameters (endpoint params) to query structure. It is needed for easier manipulation on the result. Like saving, merging fields etc...

It breaks back compatibility in some cases. For example:
```
using Serde
using CryptoExchangeAPIs.Gateio

query = Gateio.Futures.TickerQuery(contract="")
result = Gateio.Futures.ticker(; settle = Gateio.Futures.Ticker.btc, query=query) 
# Gateio.Futures.ticker(; settle = Gateio.Futures.Ticker.btc, contract="")  # will work
```

- [x] Did you bump the project version?
- [x] Did you add a description to the Pull Request?
- [ ] Did you add new tests?
- [x] Did you add reviewers?
