### PR TITLE
Fix typo in price24hPcnt field mapping

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CryptoExchangeAPIs"
 uuid = "5e3d4798-c815-4641-85e1-deed530626d3"
-version = "0.34.0"
+version = "0.34.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/Bybit/Spot/API/Ticker.jl
+++ b/src/Bybit/Spot/API/Ticker.jl
@@ -35,7 +35,7 @@ struct TickerData <: BybitData
     ask1Size::Maybe{Float64}
     lastPrice::Float64
     prevPrice24h::Float64
-    pice24hPcnt::Maybe{Float64}
+    price24hPcnt::Maybe{Float64}
     highPrice24h::Float64
     lowPrice24h::Float64
     turnover24h::Float64
@@ -88,7 +88,7 @@ to_pretty_json(result.result)
         "ask1Size":0.124391,
         "lastPrice":90976.95,
         "prevPrice24h":94379.41,
-        "pice24hPcnt":null,
+        "price24hPcnt":null,
         "highPrice24h":95950.05,
         "lowPrice24h":90547.11,
         "turnover24h":2.838946290225581e9,


### PR DESCRIPTION
Fix: correct typo in `price24hPcnt` field of TickerData structure

- [x] Did you bump the project version?
- [x] Did you add a description to the Pull Request?
- [ ] Did you add new tests?
- [ ] Did you add reviewers?
