### PR TITLE
Fix Huobi Spot link in README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Then, to install CryptoExchangeAPIs, simply use the Julia package manager:
                 <td><img src="docs/src/assets/huobi.png" alt="Huobi Logo" width="20" height="20"></td>
                 <td><a href="https://www.htx.com/">Huobi</a></td>
                 <td><a href="https://www.htx.com/en-us/opend/newApiPages">Spot</a></td>
-                <td><a href="src/Huobi/Futures">CryptoExchangeAPIs.Huobi.Spot</a></td>
+                <td><a href="src/Huobi/Spot">CryptoExchangeAPIs.Huobi.Spot</a></td>
                 <td><a href="https://bhftbootcamp.github.io/CryptoExchangeAPIs.jl/stable/pages/Huobi/#Spot">Spot</a></td>
             </tr>
             <tr>


### PR DESCRIPTION
## Summary
- Fix copy-paste error in the Huobi Spot row of the exchange table: the Module column link pointed to `src/Huobi/Futures` instead of `src/Huobi/Spot`, while the text correctly read `CryptoExchangeAPIs.Huobi.Spot`

## Test plan
- [x] Verify the link in the Huobi Spot row now correctly points to `src/Huobi/Spot`
- [x] Confirm the module text `CryptoExchangeAPIs.Huobi.Spot` remains unchanged