### PR TITLE
Add 21 new OKX fields to InstrumentsData

### DIFF
--- a/src/Okx/API/V5/Public/Instruments.jl
+++ b/src/Okx/API/V5/Public/Instruments.jl
@@ -37,35 +37,56 @@ Base.@kwdef struct InstrumentsQuery <: OkxPublicQuery
 end
 
 struct InstrumentsData <: OkxData
-    instId::String
+    alias::Maybe{String}
+    auctionEndTime::Maybe{String}
     baseCcy::Maybe{String}
-    quoteCcy::Maybe{String}
+    category::Maybe{String}
+    contTdSwTime::Maybe{String}
     ctMult::Maybe{String}
     ctType::Maybe{String}
     ctVal::Maybe{Float64}
     ctValCcy::Maybe{String}
     expTime::Maybe{NanoDate}
+    freq::Maybe{String}
+    futureSettlement::Maybe{Bool}
+    groupId::Maybe{String}
+    instCategory::Maybe{String}
     instFamily::Maybe{String}
+    instId::String
+    instIdCode::Maybe{Int64}
     instType::InstType.T
     lever::Maybe{Float64}
     listTime::NanoDate
+    longPosRemainingQuota::Maybe{String}
     lotSz::Maybe{Float64}
     maxIcebergSz::Maybe{Float64}
     maxLmtAmt::Maybe{Float64}
     maxLmtSz::Maybe{Int64}
     maxMktAmt::Maybe{Float64}
     maxMktSz::Maybe{Int64}
+    maxPlatOICoinLmt::Maybe{String}
+    maxPlatOILmt::Maybe{String}
     maxStopSz::Maybe{Int64}
     maxTriggerSz::Maybe{Float64}
     maxTwapSz::Maybe{Float64}
+    method::Maybe{String}
     minSz::Maybe{Float64}
+    openType::Maybe{String}
     optType::Maybe{String}
-    settleCcy::Maybe{String}
-    state::State.T
+    posLmtAmt::Maybe{String}
+    posLmtPct::Maybe{String}
+    preMktSwTime::Maybe{String}
+    quoteCcy::Maybe{String}
     ruleType::Maybe{String}
+    seriesId::Maybe{String}
+    settleCcy::Maybe{String}
+    shortPosRemainingQuota::Maybe{String}
+    state::State.T
     stk::Maybe{Float64}
     tickSz::Maybe{Float64}
+    tradeQuoteCcyList::Maybe{Vector{Any}}
     uly::Maybe{String}
+    upcChg::Maybe{Vector{Any}}
 end
 
 function Serde.isempty(::Type{InstrumentsData}, x)


### PR DESCRIPTION
## Summary
- OKX added 21 new fields to `/api/v5/public/instruments` response causing `APIsUndefError` during deserialization
- Added all missing fields to `InstrumentsData` struct: `alias`, `auctionEndTime`, `category`, `contTdSwTime`, `freq`, `futureSettlement`, `groupId`, `instCategory`, `instIdCode`, `longPosRemainingQuota`, `maxPlatOICoinLmt`, `maxPlatOILmt`, `method`, `openType`, `posLmtAmt`, `posLmtPct`, `preMktSwTime`, `seriesId`, `shortPosRemainingQuota`, `tradeQuoteCcyList`, `upcChg`
- Verified against all instTypes (SPOT, MARGIN, SWAP, FUTURES) — all fields covered

## Test plan
- [x] Verified OKX API response fields for all instTypes
- [ ] Run existing test suite
- [ ] Confirm `instruments(; instType=SWAP)` no longer throws `APIsUndefError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)