### PR TITLE
Standardize API patterns across exchanges

### DIFF
--- a/src/Aevo/Utils.jl
+++ b/src/Aevo/Utils.jl
@@ -1,5 +1,7 @@
 # Aevo/Utils
 
+Serde.isempty(::Type{<:AevoData}, x::String) = isempty(x)
+
 function Serde.deser(::Type{<:AevoData}, ::Type{<:Maybe{NanoDate}}, x::String)::NanoDate
     return unixnanos2nanodate(parse(Int64, x))
 end

--- a/src/Binance/FAPI/V1/ExchangeInfo.jl
+++ b/src/Binance/FAPI/V1/ExchangeInfo.jl
@@ -55,7 +55,7 @@ struct Symbols <: BinanceData
     quoteAsset::String
     quotePrecision::Int64
     requiredMarginPercent::Float64
-    settlePlan::Union{Nothing,Int64}
+    settlePlan::Maybe{Int64}
     status::String
     symbol::String
     timeInForce::Vector{String}

--- a/src/Bitfinex/Bitfinex.jl
+++ b/src/Bitfinex/Bitfinex.jl
@@ -123,11 +123,11 @@ function CryptoExchangeAPIs.request_sign!(::BitfinexClient, query::Q, ::String):
     return query
 end
 
-function CryptoExchangeAPIs.request_sign!(client::BitfinexClient, query::Q, endpoint::String)::Nothing where {Q<:BitfinexPrivateQuery}
-    query.nonce = string(round(Int64, 1000 * datetime2unix(now(UTC))))   
+function CryptoExchangeAPIs.request_sign!(client::BitfinexClient, query::Q, endpoint::String)::Q where {Q<:BitfinexPrivateQuery}
+    query.nonce = string(round(Int64, 1000 * datetime2unix(now(UTC))))
     signature_payload = string("/api/", endpoint, query.nonce)
     query.signature = hexdigest("sha384", client.config.secret_key, signature_payload)
-    return nothing
+    return query
 end
 
 function CryptoExchangeAPIs.request_body(::Q)::String where {Q<:BitfinexCommonQuery}

--- a/src/Bitfinex/Utils.jl
+++ b/src/Bitfinex/Utils.jl
@@ -1,5 +1,7 @@
 # Bitfinex/Utils
 
+Serde.isempty(::Type{<:BitfinexData}, x::String) = isempty(x)
+
 function Serde.deser(::Type{<:BitfinexData}, ::Type{<:Maybe{NanoDate}}, x::Int64)::NanoDate
     return unixnanos2nanodate(x * 1e6)
 end

--- a/src/Bithumb/Utils.jl
+++ b/src/Bithumb/Utils.jl
@@ -1,5 +1,7 @@
 # Bithumb/Utils
 
+Serde.isempty(::Type{<:BithumbData}, x::String) = isempty(x)
+
 function Serde.deser(::Type{<:BithumbData}, ::Type{<:Maybe{NanoDate}}, x::Int64)::NanoDate
     return unixnanos2nanodate(x * 1e6)
 end

--- a/src/Deribit/Utils.jl
+++ b/src/Deribit/Utils.jl
@@ -1,5 +1,7 @@
 # Deribit/Utils
 
+Serde.isempty(::Type{<:DeribitData}, x::String) = isempty(x)
+
 function Serde.deser(::Type{<:DeribitData}, ::Type{<:Maybe{NanoDate}}, x::Int64)::NanoDate
     return unixnanos2nanodate(x * 1e6)
 end

--- a/src/Huobi/Huobi.jl
+++ b/src/Huobi/Huobi.jl
@@ -171,7 +171,7 @@ function CryptoExchangeAPIs.request_sign!(::HuobiClient, query::Q, ::String)::Q 
     return query
 end
 
-function CryptoExchangeAPIs.request_sign!(client::HuobiClient, query::Q, endpoint::String)::Nothing where {Q<:HuobiPrivateQuery}
+function CryptoExchangeAPIs.request_sign!(client::HuobiClient, query::Q, endpoint::String)::Q where {Q<:HuobiPrivateQuery}
     query.AccessKeyId = client.config.public_key
     query.Timestamp = now(UTC)
     query.SignatureMethod = "HmacSHA256"
@@ -182,7 +182,7 @@ function CryptoExchangeAPIs.request_sign!(client::HuobiClient, query::Q, endpoin
     host = last(split(client.config.base_url, "//"))
     salt = join(["GET", host, endpoint, body], "\n")
     query.Signature = Base64.base64encode(digest("sha256", client.config.secret_key, salt))
-    return nothing
+    return query
 end
 
 function CryptoExchangeAPIs.request_body(::Q)::String where {Q<:HuobiPublicQuery}

--- a/src/Huobi/Utils.jl
+++ b/src/Huobi/Utils.jl
@@ -1,4 +1,6 @@
-# Houbi/Utils
+# Huobi/Utils
+
+Serde.isempty(::Type{<:HuobiData}, x::String) = isempty(x)
 
 function Serde.deser(::Type{<:Union{Data,DataTick}}, ::Type{<:Maybe{NanoDate}}, x::Int64)::NanoDate
     return unixnanos2nanodate(x * 1e6)

--- a/src/Kraken/Utils.jl
+++ b/src/Kraken/Utils.jl
@@ -1,5 +1,7 @@
 # Kraken/Utils
 
+Serde.isempty(::Type{<:KrakenData}, x::String) = isempty(x)
+
 function Serde.deser(::Type{<:KrakenData}, ::Type{<:Maybe{NanoDate}}, x::Real)::NanoDate
     return unixnanos2nanodate(x * 1e9)
 end

--- a/src/Mexc/API/V3/ExchangeInfo.jl
+++ b/src/Mexc/API/V3/ExchangeInfo.jl
@@ -75,7 +75,7 @@ struct Symbol <: MexcData
     maxQuoteAmountMarket::Float64
     fullName::String
     tradeSideType::TradeSide.T
-    contractAddress::String
+    contractAddress::Maybe{String}
     st::Bool
 end
 

--- a/src/Mexc/Utils.jl
+++ b/src/Mexc/Utils.jl
@@ -1,3 +1,5 @@
+Serde.isempty(::Type{<:MexcData}, x::String) = isempty(x)
+
 function Serde.SerQuery.ser_type(::Type{<:MexcCommonQuery}, dt::DateTime)
     return round(Int, 1000 * datetime2unix(dt))
 end

--- a/src/Okx/API/V5/Public/Instruments.jl
+++ b/src/Okx/API/V5/Public/Instruments.jl
@@ -61,12 +61,12 @@ struct InstrumentsData <: OkxData
     lotSz::Maybe{Float64}
     maxIcebergSz::Maybe{Float64}
     maxLmtAmt::Maybe{Float64}
-    maxLmtSz::Maybe{Int64}
+    maxLmtSz::Maybe{Float64}
     maxMktAmt::Maybe{Float64}
-    maxMktSz::Maybe{Int64}
+    maxMktSz::Maybe{Float64}
     maxPlatOICoinLmt::Maybe{String}
     maxPlatOILmt::Maybe{String}
-    maxStopSz::Maybe{Int64}
+    maxStopSz::Maybe{Float64}
     maxTriggerSz::Maybe{Float64}
     maxTwapSz::Maybe{Float64}
     method::Maybe{String}

--- a/src/Upbit/Utils.jl
+++ b/src/Upbit/Utils.jl
@@ -1,5 +1,7 @@
 # Upbit/Utils
 
+Serde.isempty(::Type{<:UpbitData}, x::String) = isempty(x)
+
 function Serde.deser(::Type{<:UpbitData}, ::Type{<:Maybe{NanoDate}}, x::Int64)::NanoDate
     return unixnanos2nanodate(x * 1e6)
 end


### PR DESCRIPTION
## Summary

- **Add `Serde.isempty` for empty strings** to 8 exchanges that were missing it: Kraken, Deribit, Mexc, Huobi, Bitfinex, Bithumb, Upbit, Aevo. Prevents deserialization failures when APIs return `""` instead of `null`.
- **Fix `request_sign!` return types** in Bitfinex and Huobi — was returning `Nothing`, now correctly returns `::Q` (the query type), matching the protocol used by all other exchanges.
- **Fix OKX `maxLmtSz`/`maxMktSz`/`maxStopSz` types** — `Int64` → `Float64`. OKX returns decimal values like `"5.6"` for these fields.
- **Fix MEXC `contractAddress` type** — `String` → `Maybe{String}`. Some MEXC symbols don't have this field.
- **Fix Binance FAPI `settlePlan` type** — `Union{Nothing,Int64}` → `Maybe{Int64}` for consistency with project convention.

## Test plan

- [x] All 16 exchange modules compile successfully
- [x] 64/68 public API methods pass (4 Bybit failures are test script enum casing, not library bugs)
- [ ] Review changes in each Utils.jl for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)